### PR TITLE
Add String::trimOrNull

### DIFF
--- a/src/Util/String.php
+++ b/src/Util/String.php
@@ -190,4 +190,29 @@ final class String
             $string
         );
     }
+
+    /**
+     * Strip whitespace (or other characters) from the beginning and end of a string. If the resulting string is empty, null is returned
+     *
+     * @param string $input The string that will be trimmed.
+     * @param string $characters The characters to be trimmed.
+     *
+     * @return string|null
+     *
+     * @throws \InvalidArgumentException if $input is not a string
+     * @throws \InvalidArgumentException if $characters is not a string
+     */
+    public static function trimOrNull($input, $characters = " \t\n\r\0\x0B")
+    {
+        if (!is_string($input)) {
+            throw new \InvalidArgumentException('$input is not a string');
+        }
+
+        if (!is_string($characters)) {
+            throw new \InvalidArgumentException('$characters is not a string');
+        }
+
+        $result = trim($input, $characters);
+        return $result === '' ? null : $result;
+    }
 }

--- a/tests/Util/StringTest.php
+++ b/tests/Util/StringTest.php
@@ -286,6 +286,38 @@ final class StringTest extends \PHPUnit_Framework_TestCase
     {
         S::ucwords('test', null);
     }
+
+    /**
+     * @test
+     * @covers ::trimOrNull
+     */
+    public function trimOrNull()
+    {
+        $this->assertSame('test', S::trimOrNull("\ntest\t"));
+        $this->assertSame(null, S::trimOrNull("\n \t"));
+    }
+
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage $input is not a string
+     * @covers ::trimOrNull
+     */
+    public function trimOrNull_badTypeInput()
+    {
+        S::trimOrNull(true);
+    }
+
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage $characters is not a string
+     * @covers ::trimOrNull
+     */
+    public function trimOrNull_badTypeCharacters()
+    {
+        S::trimOrNull("\n test\t", true);
+    }
 }
 
 class TestObjectWithToString


### PR DESCRIPTION
Trim a string returning the result or null if the resulting trimmed string is empty.

```php
String::trimOrNull("\ttest\n") === 'test'
String::trim("         ") === null
```