### PR TITLE
Add Arrays::changeKeyCase

### DIFF
--- a/src/Util/Arrays.php
+++ b/src/Util/Arrays.php
@@ -10,6 +10,11 @@ namespace DominionEnterprises\Util;
  */
 final class Arrays
 {
+    const CASE_LOWER = 1;
+    const CASE_UPPER = 2;
+    const CASE_CAMEL_CAPS = 4;
+    const CASE_UNDERSCORE = 8;
+
     /**
      * Simply returns an array value if the key exist or null if it does not.
      *
@@ -410,5 +415,49 @@ final class Arrays
                 $value = null;
             }
         }
+    }
+
+    /**
+     * Changes the case of all keys in an array.
+     *
+     * @param array   $input The array to work on.
+     * @param integer $case  The case to which the keys should be set.
+     *
+     * @return array Returns an array with its keys case changed.
+     */
+    public static function changeKeyCase(array $input, $case = self::CASE_LOWER)
+    {
+        if ($case & self::CASE_UNDERSCORE) {
+            $copy = [];
+            array_walk(
+                $input,
+                function ($value, $key) use (&$copy) {
+                    $copy[preg_replace("/([a-z])([A-Z0-9])/", '$1_$2', $key)] = $value;
+                }
+            );
+            $input = $copy;
+        }
+
+        if ($case & self::CASE_CAMEL_CAPS) {
+            $copy = [];
+            array_walk(
+                $input,
+                function ($value, $key) use (&$copy) {
+                    $key = lcfirst(str_replace(' ', '', ucwords(strtolower(str_replace('_', ' ', $key)))));
+                    $copy[$key] = $value;
+                }
+            );
+            $input = $copy;
+        }
+
+        if ($case & self::CASE_UPPER) {
+            $input = array_change_key_case($input, \CASE_UPPER);
+        }
+
+        if ($case & self::CASE_LOWER) {
+            $input = array_change_key_case($input, \CASE_LOWER);
+        }
+
+        return $input;
     }
 }

--- a/tests/Util/ArraysTest.php
+++ b/tests/Util/ArraysTest.php
@@ -787,4 +787,72 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
         A::nullifyEmptyStrings($array);
         $this->assertSame([], $array);
     }
+
+    /**
+     * Verify functionality of changeKeyCase().
+     *
+     * @test
+     * @covers ::changeKeyCase
+     * @dataProvider changeKeyCaseData
+     *
+     * @return void
+     */
+    public function changeKeyCase($input, $case, $expected)
+    {
+        $this->assertSame($expected, A::changeKeyCase($input, $case));
+    }
+
+    /**
+     * Dataprovider for changeKeyCase test.
+     *
+     * @return array
+     */
+    public function changeKeyCaseData()
+    {
+        $lowerUnderscore = [
+            'first_and_last_name' => 'John Doe',
+            'email_address' => 'john@example.com',
+            'age' => 35,
+        ];
+
+        $upperUnderscore = [
+            'FIRST_AND_LAST_NAME' => 'John Doe',
+            'EMAIL_ADDRESS' => 'john@example.com',
+            'AGE' => 35,
+        ];
+
+        $camelCaps = [
+            'firstAndLastName' => 'John Doe',
+            'emailAddress' => 'john@example.com',
+            'age' => 35,
+        ];
+
+        $underscore = [
+            'first_And_Last_Name' => 'John Doe',
+            'email_Address' => 'john@example.com',
+            'age' => 35,
+        ];
+
+        $lower = [
+            'firstandlastname' => 'John Doe',
+            'emailaddress' => 'john@example.com',
+            'age' => 35,
+        ];
+
+        $upper = [
+            'FIRSTANDLASTNAME' => 'John Doe',
+            'EMAILADDRESS' => 'john@example.com',
+            'AGE' => 35,
+        ];
+
+        return [
+            'upper to lower' => [$upper, A::CASE_LOWER, $lower],
+            'lower to upper' => [$lower, A::CASE_UPPER, $upper],
+            'underscore to camel' => [$lowerUnderscore, A::CASE_CAMEL_CAPS, $camelCaps],
+            'camel to underscore' => [$camelCaps, A::CASE_UNDERSCORE, $underscore],
+            'camel to upper underscore' => [$camelCaps, A::CASE_UNDERSCORE | A::CASE_UPPER, $upperUnderscore],
+            'camel to lower underscore' => [$camelCaps, A::CASE_UNDERSCORE | A::CASE_LOWER, $lowerUnderscore],
+            'lower underscore to upper camel' => [$lowerUnderscore, A::CASE_CAMEL_CAPS | A::CASE_UPPER, $upper],
+        ];
+    }
 }


### PR DESCRIPTION
Allow arrays to go from underscored keys to camel caps keys, or vice versa.

```php
$input = [
    'EMAIL_ADDRESS' => 'user@example.com',
    'FIRST_NAME' => 'John',
    'LAST_NAME' => 'Doe',
];

$output = Arrays::changeKeyCase($input, Arrays::CASE_CAMEL_CAPS);

var_dump($output);
```
The above code would output 

```
array(3) {
  'emailAddress' =>
  string(16) "user@example.com"
  'firstName' =>
  string(4) "John"
  'lastName' =>
  string(3) "Doe"
}
```